### PR TITLE
Use learning config to create KBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.1 (unreleased)
 
 
-- Nothing changed yet.
+- Use `learning_configuration` for creating KBs instead of `vector_similarity`
 
 
 ## 2.0.0 (2024-02-18)

--- a/nuclia/sdk/nucliadb.py
+++ b/nuclia/sdk/nucliadb.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from nucliadb_models.resource import KnowledgeBoxList, KnowledgeBoxObj
-from nucliadb_models.vectors import VectorSimilarity
 
 from nuclia.data import get_auth
 from nuclia.decorators import nucliadb
@@ -26,13 +25,13 @@ class NucliaDB:
         *,
         slug: str,
         title: str,
-        similarity: Optional[VectorSimilarity] = None,
+        learning_config: Optional[dict] = None,
         default: bool = False,
         **kwargs,
     ) -> KnowledgeBoxObj:
         ndb: NucliaDBClient = kwargs["ndb"]
         kb: KnowledgeBoxObj = ndb.ndb.create_knowledge_box(
-            slug=slug, title=title, similarity=similarity
+            slug=slug, title=title, learning_config=learning_config
         )
         if default:
             self._auth.kb(url=f"{ndb.ndb.base_url}/v1/kb/{kb.uuid}")

--- a/nuclia/sdk/nucliadb.py
+++ b/nuclia/sdk/nucliadb.py
@@ -25,13 +25,13 @@ class NucliaDB:
         *,
         slug: str,
         title: str,
-        learning_config: Optional[dict] = None,
+        learning_configuration: Optional[dict] = None,
         default: bool = False,
         **kwargs,
     ) -> KnowledgeBoxObj:
         ndb: NucliaDBClient = kwargs["ndb"]
         kb: KnowledgeBoxObj = ndb.ndb.create_knowledge_box(
-            slug=slug, title=title, learning_config=learning_config
+            slug=slug, title=title, learning_configuration=learning_configuration
         )
         if default:
             self._auth.kb(url=f"{ndb.ndb.base_url}/v1/kb/{kb.uuid}")

--- a/nuclia/tests/test_nucliadb/test_crud.py
+++ b/nuclia/tests/test_nucliadb/test_crud.py
@@ -21,7 +21,11 @@ async def test_crud(nucliadb: NucliaFixture, event_loop: BaseEventLoop):
     listing_kbs: KnowledgeBoxList = await event_loop.run_in_executor(None, ndb.list)
     assert len(listing_kbs.kbs) == 0
     creation = partial(
-        ndb.create, slug="kb", title="title", similarity="dot", default=True
+        ndb.create,
+        slug="kb",
+        title="title",
+        learning_config={"semantic_model": "english"},
+        default=True,
     )
 
     kb_obj: KnowledgeBoxObj = await event_loop.run_in_executor(None, creation)

--- a/nuclia/tests/test_nucliadb/test_crud.py
+++ b/nuclia/tests/test_nucliadb/test_crud.py
@@ -24,7 +24,7 @@ async def test_crud(nucliadb: NucliaFixture, event_loop: BaseEventLoop):
         ndb.create,
         slug="kb",
         title="title",
-        learning_config={"semantic_model": "english"},
+        learning_configuration={"semantic_model": "english"},
         default=True,
     )
 


### PR DESCRIPTION
`vector_similarity` parameter is deprecated. `learning_configuration` should be used instead