### PR TITLE
Handle nucliadb back pressure rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.11 (unreleased)
 
 
-- Nothing changed yet.
+- Handle nucliadb back pressure with backoff
 
 
 ## 2.0.10 (2024-03-26)

--- a/nuclia/exceptions.py
+++ b/nuclia/exceptions.py
@@ -28,3 +28,7 @@ class AlreadyConsumed(Exception):
 
 class GettingRemoteFileError(Exception):
     pass
+
+
+class RateLimitError(Exception):
+    pass

--- a/nuclia/lib/utils.py
+++ b/nuclia/lib/utils.py
@@ -3,7 +3,7 @@ from typing import Union
 import httpx
 import requests
 
-from nuclia.exceptions import UserTokenExpired
+from nuclia.exceptions import RateLimitError, UserTokenExpired
 
 
 def handle_http_errors(response: Union[httpx.Response, requests.models.Response]):
@@ -12,5 +12,7 @@ def handle_http_errors(response: Union[httpx.Response, requests.models.Response]
         and "Hydra token is either unexistent or revoked" in response.text
     ):
         raise UserTokenExpired()
+    elif response.status_code == 429:
+        raise RateLimitError(f"Rate limited: {response.text}")
     elif response.status_code >= 400:
         raise httpx.HTTPError(f"Status code {response.status_code}: {response.text}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ nucliadb_sdk>=2.44.1
 nucliadb_models>=2.44.1
 tqdm
 aiofiles
+backoff


### PR DESCRIPTION
Now that NucliaDB can return 429 due to back pressure, handle it with a simple back off strategy