### PR TITLE
Update GHA dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v0
+        uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
+
       - name: Push SDK docs to GCS
         run: gsutil rsync -r ./docs gs://${{ secrets.DOCS_STORAGE }}/python-sdk

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: 'pip'

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: 'pip'


### PR DESCRIPTION
GHA was complaining about some actions using Node 16 instead of 20. This PR updates all our dependency actions (not only the ones using node)