### PR TITLE
Add nucliadb_protos dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ httpcore>=1.0.0
 prompt_toolkit
 nucliadb_sdk>=6.2.1.post2735,<7
 nucliadb_models>=6.2.1.post2735,<7
+nucliadb_protos>=6.2.1.post2735,<7
 nuclia-models>=0.24.3
 tqdm
 aiofiles


### PR DESCRIPTION
nuclia.py should have nucliadb_protos as a dependency as it is using it directly
https://github.com/nuclia/nuclia.py/blob/add-proto-dependency/nuclia/sdk/process.py#L3