### PR TITLE
Adjust codecov to require project coverage increase and relax patch

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -2,16 +2,16 @@ coverage:
   status:
     project:
       default:
-        target: 80%
-        # our current (Aug 2025) we have around 55% code coverage. We'll want to
-        # decrease this threshold once we go up to our desired coverage target
-        threshold: 25%
+        # We want to always increase project code coverage until we reach a good
+        # point (~80%)
+        target: auto
+        threshold: 0%
 
     patch:
       default:
         # if we want to reach more coverage with time, we must enforce new code
         # comes tested
-        target: 85%
+        target: 75%
 
 ignore:
   - "**/tests/**"


### PR DESCRIPTION
Patch coverage at 85% was really hard to get. Here I'm lowering it down to something more reasonable but enforcing project coverage to always increase with 0 tolerance.