### PR TITLE
Update domains to rag.progress.cloud

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,4 +1,4 @@
-name: Test on nuclia.cloud
+name: Test on rag.progress.cloud
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   repository_dispatch:
-    type: test-prod
+    types: [test-prod]
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   repository_dispatch:
-    type: test-stage
+    types: [test-stage]
 
 jobs:
   test:
@@ -31,4 +31,4 @@ jobs:
         run: uv sync --no-editable --all-extras
 
       - name: Test
-        run: uv run nuclia kb list --url="https://europe-1.nuclia.cloud/api/v1/kb/eb720a59-f879-4b23-a995-605f91c874f4" --api_key="${{ secrets.PROD_API_KEY_FOR_WINDOWS_TEST }}"
+        run: uv run nuclia kb list --url="https://europe-1.rag.progress.cloud/api/v1/kb/eb720a59-f879-4b23-a995-605f91c874f4" --api_key="${{ secrets.PROD_API_KEY_FOR_WINDOWS_TEST }}"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install nuclia
 
 ### Nuclia
 
-You can login with your Nuclia user [How to sign-up](https://nuclia.cloud/user/signup) via
+You can login with your Nuclia user [How to sign-up](https://rag.progress.cloud/user/signup) via
 
 ```bash
 nuclia auth login

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ nuclia auth login
 
 ### Nuclia Knowledgebox
 
-You can login to a specific knowledgebox if you have a Service Token (How to get a Service Token) or your NucliaDB is [deployed on-premise](https://docs.nuclia.dev/docs/nucliadb/deploy)
+You can login to a specific knowledgebox if you have a Service Token (How to get a Service Token) or your NucliaDB is [deployed on-premise](https://docs.rag.progress.cloud/docs/nucliadb/deploy)
 
 ```bash
 nuclia auth kb --url KB_URL --token SERVICE_TOKEN

--- a/docs/02-auth.md
+++ b/docs/02-auth.md
@@ -63,7 +63,7 @@ You define its expiration date (default is 90 days), and you can revoke it at an
 
 ## API key
 
-An API key can be generated from the Nuclia Dashboard, see [Get an API key](https://docs.nuclia.dev/docs/guides/getting-started/quick-start/push#get-an-api-key).
+An API key can be generated from the Nuclia Dashboard, see [Get an API key](https://docs.rag.progress.cloud/docs/guides/getting-started/quick-start/push#get-an-api-key).
 
 When authenticating with an API key, you can only access the Knowledge Box that is associated with this API key.
 The authentication will last as long as the key is valid (potentially forever, but an API key can be revoked from the Nuclia Dashboard).

--- a/docs/03-kb.md
+++ b/docs/03-kb.md
@@ -56,13 +56,13 @@ You can create a resource in a Knowledge Box, setting all the resource metadata,
 - `icon`: the mimetype you want to assign to the resource (by default, Nuclia will assign the mimetype corresponding to the first field added in the resource)
 - `metadata`:
 - `origin`: the origin metadata of the resource
-  See [API documenattion](https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
+  See [API documenattion](https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
 - `usermetadata`: User metadata, mostly used to set labels on the resource
-  See [API documenattion](https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
+  See [API documenattion](https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
 - `fieldmetadata`: Field metadata
-  See [API documenattion](https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
+  See [API documenattion](https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
 - `origin`: Origin metadata
-  See [API documenattion](https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
+  See [API documenattion](https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post)
 - `extra`: user-defined metadata
 
 You can also set the contents of the resource, as fields:

--- a/docs/05-search.md
+++ b/docs/05-search.md
@@ -116,7 +116,7 @@ RAG strategies can be used to improve the quality of the answers by extending th
   search.ask(query="My question", rag_strategies=[{"name": "hierarchy"}])
   ```
 
-See the [RAG strategies documentation](https://docs.nuclia.dev/docs/rag/rag-strategy) for more information.
+See the [RAG strategies documentation](https://docs.rag.progress.cloud/docs/rag/rag-strategy) for more information.
 
 ## Complex queries
 
@@ -168,4 +168,4 @@ a bit cumbersome, the knowledge graph can be queried as in this example:
   ```
 
 For more information about graph querying, please refer to [Nuclia's graph
-doc](https://docs.nuclia.dev/docs/rag/advanced/graph) or the [API reference](https://docs.nuclia.dev/docs/api#tag/Search/operation/graph_search_knowledgebox_kb__kbid__graph_post)
+doc](https://docs.rag.progress.cloud/docs/rag/advanced/graph) or the [API reference](https://docs.rag.progress.cloud/docs/api#tag/Search/operation/graph_search_knowledgebox_kb__kbid__graph_post)

--- a/docs/13-ai-agents.md
+++ b/docs/13-ai-agents.md
@@ -11,7 +11,7 @@ With the `crewAI` Python library and the `NucliaNuaChat` class, you can integrat
    pip install crewai nuclia[litellm]
    ```
 
-2. Obtain your Nuclia [NUA key](https://docs.nuclia.dev/docs/management/authentication#generate-nua-key)
+2. Obtain your Nuclia [NUA key](https://docs.rag.progress.cloud/docs/management/authentication#generate-nua-key)
 
 ## How to Integrate crewAI Agents with Nuclia LLMs
 

--- a/nuclia/__init__.py
+++ b/nuclia/__init__.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 from urllib.parse import urlparse
 
-BASE_DOMAIN = os.environ.get("BASE_NUCLIA_DOMAIN", "nuclia.cloud")
+BASE_DOMAIN = os.environ.get("BASE_NUCLIA_DOMAIN", "rag.progress.cloud")
 BASE = f"https://{BASE_DOMAIN}"
 REGIONAL = "https://{region}." + BASE_DOMAIN
 CLOUD_ID = BASE.split("/")[-1]

--- a/nuclia/sdk/search.py
+++ b/nuclia/sdk/search.py
@@ -88,7 +88,7 @@ class NucliaSearch:
         """
         Perform a search query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Search_Knowledge_Box_kb__kbid__search_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Search_Knowledge_Box_kb__kbid__search_post
         """
         ndb: NucliaDBClient = kwargs["ndb"]
         if isinstance(query, str):
@@ -120,7 +120,7 @@ class NucliaSearch:
         """
         Perform a find query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Find_Knowledge_Box_kb__kbid__find_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Find_Knowledge_Box_kb__kbid__find_post
         """
         ndb: NucliaDBClient = kwargs["ndb"]
         if isinstance(query, str) and highlight is not None:
@@ -158,7 +158,7 @@ class NucliaSearch:
         """
         Perform a catalog query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/catalog_post_kb__kbid__catalog_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/catalog_post_kb__kbid__catalog_post
         """
         ndb: NucliaDBClient = kwargs["ndb"]
         if isinstance(query, str):
@@ -194,7 +194,7 @@ class NucliaSearch:
         """
         Answer a question.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
         """
         ndb: NucliaDBClient = kwargs["ndb"]
         if isinstance(query, str):
@@ -274,7 +274,7 @@ class NucliaSearch:
         """
         Answer a question.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
         """
         ndb: NucliaDBClient = kwargs["ndb"]
         if isinstance(schema, str):
@@ -362,7 +362,7 @@ class NucliaSearch:
         """
         Perform a graph path query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/graph_search_knowledgebox_kb__kbid__graph_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/graph_search_knowledgebox_kb__kbid__graph_post
         """
         ndb: NucliaDBClient = kwargs["ndb"]
 
@@ -406,7 +406,7 @@ class AsyncNucliaSearch:
         """
         Perform a search query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Search_Knowledge_Box_kb__kbid__search_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Search_Knowledge_Box_kb__kbid__search_post
         """
         ndb: AsyncNucliaDBClient = kwargs["ndb"]
         if isinstance(query, str):
@@ -438,7 +438,7 @@ class AsyncNucliaSearch:
         """
         Perform a find query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Find_Knowledge_Box_kb__kbid__find_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Find_Knowledge_Box_kb__kbid__find_post
         """
 
         ndb: AsyncNucliaDBClient = kwargs["ndb"]
@@ -474,7 +474,7 @@ class AsyncNucliaSearch:
         """
         Perform a catalog query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/catalog_post_kb__kbid__catalog_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/catalog_post_kb__kbid__catalog_post
         """
         ndb: AsyncNucliaDBClient = kwargs["ndb"]
         if isinstance(query, str):
@@ -509,7 +509,7 @@ class AsyncNucliaSearch:
         """
         Answer a question.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
         """
         ndb: AsyncNucliaDBClient = kwargs["ndb"]
 
@@ -618,7 +618,7 @@ class AsyncNucliaSearch:
         """
         Answer a question.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
         """
         ndb: AsyncNucliaDBClient = kwargs["ndb"]
         if isinstance(query, str):
@@ -664,7 +664,7 @@ class AsyncNucliaSearch:
         """
         Answer a question.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/Ask_Knowledge_Box_kb__kbid__ask_post
         """
         ndb: AsyncNucliaDBClient = kwargs["ndb"]
 
@@ -770,7 +770,7 @@ class AsyncNucliaSearch:
         """
         Perform a graph path query.
 
-        See https://docs.nuclia.dev/docs/api#tag/Search/operation/graph_search_knowledgebox_kb__kbid__graph_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Search/operation/graph_search_knowledgebox_kb__kbid__graph_post
         """
         ndb: AsyncNucliaDBClient = kwargs["ndb"]
 

--- a/nuclia/sdk/upload.py
+++ b/nuclia/sdk/upload.py
@@ -43,11 +43,11 @@ class NucliaUpload:
     - `field`: Field id. If not provided, a unique value will be generated.
     - `title`: resource title.
     - `usermetadata`: User metadata.
-        See https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
     - `fieldmetadata`: Field metadata.
-        See https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
     - `origin`: Origin metadata.
-        See https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
     - `extra`: user-defined metadata.
     """
 
@@ -377,11 +377,11 @@ class AsyncNucliaUpload:
     - `field`: Field id. If not provided, a unique value will be generated.
     - `title`: resource title.
     - `usermetadata`: User metadata.
-        See https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
     - `fieldmetadata`: Field metadata.
-        See https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
     - `origin`: Origin metadata.
-        See https://docs.nuclia.dev/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
+        See https://docs.rag.progress.cloud/docs/api#tag/Resources/operation/Create_Resource_kb__kbid__resources_post
     - `extra`: user-defined metadata.
     """
 

--- a/nuclia/tests/fixtures.py
+++ b/nuclia/tests/fixtures.py
@@ -16,7 +16,7 @@ else:
     IS_PROD = True
     TESTING_ACCOUNT_SLUG = "nuclia"
     TESTING_KBID = "18ab102c-a7db-4a35-b894-c20422b3b9f0"
-    TESTING_KB = "https://europe-1.nuclia.cloud/api/v1/kb/" + TESTING_KBID
+    TESTING_KB = "https://europe-1.rag.progress.cloud/api/v1/kb/" + TESTING_KBID
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This pull request updates all references from `nuclia.cloud` to `rag.progress.cloud` throughout the codebase, documentation, and CI workflows. The goal is to ensure consistency with the new domain and documentation URLs, which affects API endpoints, authentication, and user instructions.

The most important changes are:

**Domain and API Endpoint Migration**

* Changed the default domain in `nuclia/__init__.py` from `nuclia.cloud` to `rag.progress.cloud`, impacting all API requests and client interactions.
* Updated test and workflow URLs in `.github/workflows/prod.yml`, `.github/workflows/windows.yml`, and `nuclia/tests/fixtures.py` to use `rag.progress.cloud` instead of `nuclia.cloud`. [[1]](diffhunk://#diff-b01f9374f6cc69f1d6b5f14f3c86dd1989076895b0d9d688f8fdddf35296acc6L1-R1) [[2]](diffhunk://#diff-b01f9374f6cc69f1d6b5f14f3c86dd1989076895b0d9d688f8fdddf35296acc6L11-R11) [[3]](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL11-R11) [[4]](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL34-R34) [[5]](diffhunk://#diff-1af0322939e87428406a35778fb8d3272e0c7ce6a797144b51536ae3b9613516L19-R19)

**Documentation Updates**

* Replaced all documentation links in `README.md` and `docs/` files to point to `rag.progress.cloud` for sign-up, deployment, API docs, RAG strategies, and authentication guides. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R21) [[2]](diffhunk://#diff-ca747d382738dd32b602d9f3db84fb95f0f4d25df00353f79fbf16b47252bbbbL66-R66) [[3]](diffhunk://#diff-1957c83f716f67cefa740fe354ad2e5aac5b08685c7b7fe4a020d303005dd432L59-R65) [[4]](diffhunk://#diff-5264447969fd27c20baa7ab50e06c82c541088b3778230f95768e56ccf866903L119-R119) [[5]](diffhunk://#diff-5264447969fd27c20baa7ab50e06c82c541088b3778230f95768e56ccf866903L171-R171) [[6]](diffhunk://#diff-c4096f9c7cf0ebcc24b3979e85493c5c88e8077b64fe9ffc23aa1c7da3be545bL14-R14)

**SDK Reference Updates**

* Updated API documentation references in all docstrings within `nuclia/sdk/search.py` and `nuclia/sdk/upload.py` to use the new domain, ensuring users are directed to the correct documentation. [[1]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L91-R91) [[2]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L123-R123) [[3]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L161-R161) [[4]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L197-R197) [[5]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L277-R277) [[6]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L365-R365) [[7]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L409-R409) [[8]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L441-R441) [[9]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L477-R477) [[10]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L512-R512) [[11]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L621-R621) [[12]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L667-R667) [[13]](diffhunk://#diff-9520bf51dc64b69201b40654774888e0eb76ee4cfe4563b672d7fde11c4b68b3L773-R773) [[14]](diffhunk://#diff-4c8fe621c2c143fcd7c9f5f5454f3ecbc94fef61775f31e5a638342f4035a537L46-R50) [[15]](diffhunk://#diff-4c8fe621c2c143fcd7c9f5f5454f3ecbc94fef61775f31e5a638342f4035a537L380-R384)

These changes ensure that all references, documentation, and code are aligned with the new `rag.progress.cloud` domain, reducing confusion and improving the developer experience.