### PR TITLE
Configure push of SDK docs into S3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,14 +4,13 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   id-token: write
   contents: read
-
-env:
-  GCP_WORKLOAD_IDENTITY_PROVIDER: "projects/224545243904/locations/global/workloadIdentityPools/gh-nuclia/providers/gh-nuclia-provider"
-  GCP_SERVICE_ACCOUNT: "github-actions@nuclia-internal.iam.gserviceaccount.com"
 
 jobs:
   publish-doc:
@@ -21,16 +20,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        id: gcp-auth-models-mount
-        uses: google-github-actions/auth@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          workload_identity_provider: "${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}"
-          service_account: "${{ env.GCP_SERVICE_ACCOUNT }}"
-          token_format: access_token
+          role-to-assume: '${{ secrets.AWS_DOCS_SYNC_ROLE }}'
+          aws-region: ${{ secrets.AWS_DOCS_SYNC_REGION }}
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
-
-      - name: Push SDK docs to GCS
-        run: gsutil rsync -d -r ./docs gs://${{ secrets.DOCS_STORAGE }}/python-sdk
+      - name: Push SDK docs to S3
+        run: aws s3 sync ./docs s3://${{ secrets.DOCS_STORAGE }}/python-sdk


### PR DESCRIPTION
This pull request updates the documentation publishing workflow to use AWS instead of Google Cloud for storing SDK docs. The workflow now authenticates with AWS and syncs documentation to an S3 bucket, replacing the previous Google Cloud Storage setup.

**Cloud provider migration:**

* Replaced Google Cloud authentication and setup steps with AWS credentials configuration using `aws-actions/configure-aws-credentials@v4` in `.github/workflows/docs.yml`.
* Changed the documentation sync command from `gsutil rsync` (GCS) to `aws s3 sync` (S3), updating the destination to an S3 bucket.

**Environment cleanup:**

* Removed environment variables related to Google Cloud authentication (`GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`).