### PR TITLE
Exclude git detector BlackDuck

### DIFF
--- a/.github/workflows/bd_sca_scanner.yml
+++ b/.github/workflows/bd_sca_scanner.yml
@@ -25,9 +25,9 @@ jobs:
         id: calculate-detect-args
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "DETECT_ARGS=--detect.included.detector.types=uv,git --detect.timeout=600 --detect.blackduck.rapid.compare.mode=BOM_COMPARE_STRICT" >> $GITHUB_OUTPUT
+            echo "DETECT_ARGS=--detect.included.detector.types=uv --detect.timeout=600 --detect.excluded.detector.types=GIT --detect.blackduck.rapid.compare.mode=BOM_COMPARE_STRICT" >> $GITHUB_OUTPUT
           else
-            echo "DETECT_ARGS=--detect.included.detector.types=uv,git --detect.timeout=600" >> $GITHUB_OUTPUT
+            echo "DETECT_ARGS=--detect.included.detector.types=uv --detect.timeout=600" >> $GITHUB_OUTPUT
           fi
 
       - name: Run Black Duck SCA PR Scan


### PR DESCRIPTION
This pull request makes a targeted change to the Black Duck SCA scanner workflow configuration. The main update is to exclude the `git` detector type from the included detectors and explicitly add it to the excluded detector types in the `DETECT_ARGS` environment variable.

Configuration update:

* Updated the `DETECT_ARGS` in `.github/workflows/bd_sca_scanner.yml` to only include the `uv` detector, exclude the `git` detector, and ensure the correct detector types are set for both pull request and non-pull request events.