### PR TITLE
Add new effort values

### DIFF
--- a/nuclia/lib/nua_responses.py
+++ b/nuclia/lib/nua_responses.py
@@ -87,7 +87,7 @@ class Reasoning(BaseModel):
         default=True,
         description="Whether to display the reasoning steps in the response.",
     )
-    effort: Literal["low", "medium", "high"] = Field(
+    effort: Literal["none", "minimal", "low", "medium", "high", "xhigh"] = Field(
         default="medium",
         description=(
             "Level of reasoning effort. Used by OpenAI models to control the depth of reasoning. "
@@ -111,7 +111,14 @@ class Reasoning(BaseModel):
             if "budget_tokens" not in data and "effort" not in data:
                 return data
 
-            effort_map = {"low": 7500, "medium": 15_000, "high": 30_000}
+            effort_map = {
+                "none": 0,
+                "minimal": 0,
+                "low": 7500,
+                "medium": 15_000,
+                "high": 30_000,
+                "xhigh": 50_000,
+            }
             if "budget_tokens" not in data:
                 if data["effort"] in effort_map:
                     data["budget_tokens"] = effort_map[data["effort"]]
@@ -131,8 +138,10 @@ class Reasoning(BaseModel):
                     data["effort"] = "low"
                 elif budget_tokens <= effort_map["medium"]:
                     data["effort"] = "medium"
-                else:
+                elif budget_tokens <= effort_map["high"]:
                     data["effort"] = "high"
+                else:
+                    data["effort"] = "xhigh"
 
         return data
 

--- a/nuclia/tests/unit/test_nua_responses.py
+++ b/nuclia/tests/unit/test_nua_responses.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nuclia.lib.nua_responses import PushPayload
+from nuclia.lib.nua_responses import PushPayload, Reasoning
 
 
 def test_uuid_validation():
@@ -11,3 +11,37 @@ def test_uuid_validation():
         PushPayload(uuid="")
     with pytest.raises(ValueError):
         PushPayload(uuid="invalid.uuid")
+
+
+@pytest.mark.parametrize(
+    "effort,expected_budget_tokens",
+    [
+        ("none", 0),
+        ("minimal", 0),
+        ("low", 7500),
+        ("medium", 15_000),
+        ("high", 30_000),
+        ("xhigh", 50_000),
+    ],
+)
+def test_reasoning_effort_sets_budget_tokens(effort, expected_budget_tokens):
+    r = Reasoning(effort=effort)
+    assert r.budget_tokens == expected_budget_tokens
+
+
+@pytest.mark.parametrize(
+    "budget_tokens,expected_effort",
+    [
+        (0, "low"),
+        (7500, "low"),
+        (7501, "medium"),
+        (15_000, "medium"),
+        (15_001, "high"),
+        (30_000, "high"),
+        (30_001, "xhigh"),
+        (50_000, "xhigh"),
+    ],
+)
+def test_reasoning_budget_tokens_sets_effort(budget_tokens, expected_effort):
+    r = Reasoning(budget_tokens=budget_tokens)
+    assert r.effort == expected_effort


### PR DESCRIPTION
Align `Reasoning.effort` in the SDK with the full set of values supported by the backend: add `"none"`, `"minimal"` and `"xhigh"`, and update the `budget_tokens` mappings accordingly.