### PR TITLE
Simplify Reasoning model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.11.2 (2026-06-03)
+
+### New Features
+
+- Add new `Reasoning.effort` values: `none`, `minimal`, and `xhigh`.
+
 ## 4.11.1 (2026-05-22)
 
 - Add KB Owner NucliaDB role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.11.2 (2026-06-03)
+
 ## 4.11.1 (2026-05-22)
 
 - Add KB Owner NucliaDB role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 4.11.2 (2026-06-03)
-
-### New Features
-
-- Add new `Reasoning.effort` values: `none`, `minimal`, and `xhigh`.
-
 ## 4.11.1 (2026-05-22)
 
 - Add KB Owner NucliaDB role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.11.2 (2026-06-03)
 
+- Add new reasoning effort values `none`, `minimal`, `xhigh`
+
 ## 4.11.1 (2026-05-22)
 
 - Add KB Owner NucliaDB role

--- a/nuclia/lib/nua_responses.py
+++ b/nuclia/lib/nua_responses.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 import pydantic
 from nuclia_models.common.consumption import Consumption
-from pydantic import BaseModel, Field, RootModel, model_validator
+from pydantic import BaseModel, Field, RootModel, field_serializer, model_validator
 from typing_extensions import Annotated, Self
 
 
@@ -91,59 +91,18 @@ class Reasoning(BaseModel):
         default="medium",
         description=(
             "Level of reasoning effort. Used by OpenAI models to control the depth of reasoning. "
-            "This parameter will be automatically mapped to budget_tokens "
-            "if the chosen model does not support effort."
+            "If the chosen model only supports budget_tokens, the server normalizes this value "
+            "to an appropriate token budget automatically."
         ),
     )
     budget_tokens: int = Field(
         default=15_000,
         description=(
             "Token budget for reasoning. Used by Anthropic or Google models to limit the number of "
-            "tokens used for reasoning. This parameter will be automatically mapped to effort "
-            "if the chosen model does not support budget_tokens."
+            "tokens used for reasoning. If the chosen model only supports effort, the server "
+            "normalizes this value to an appropriate effort level automatically."
         ),
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def set_budget_tokens_or_effort(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            if "budget_tokens" not in data and "effort" not in data:
-                return data
-
-            effort_map = {
-                "none": 0,
-                "minimal": 0,
-                "low": 7500,
-                "medium": 15_000,
-                "high": 30_000,
-                "xhigh": 50_000,
-            }
-            if "budget_tokens" not in data:
-                if data["effort"] in effort_map:
-                    data["budget_tokens"] = effort_map[data["effort"]]
-                else:
-                    raise ValueError(
-                        f"Invalid effort value: {data['effort']}. "
-                        f"Valid values are: {', '.join(effort_map.keys())}."
-                    )
-            if "effort" not in data:
-                budget_tokens = data["budget_tokens"]
-                if not isinstance(budget_tokens, int):
-                    raise ValueError(
-                        f"Invalid budget_tokens value: {budget_tokens}. "
-                        "It must be an integer."
-                    )
-                if budget_tokens <= effort_map["low"]:
-                    data["effort"] = "low"
-                elif budget_tokens <= effort_map["medium"]:
-                    data["effort"] = "medium"
-                elif budget_tokens <= effort_map["high"]:
-                    data["effort"] = "high"
-                else:
-                    data["effort"] = "xhigh"
-
-        return data
 
 
 class CitationsType(str, Enum):
@@ -247,14 +206,13 @@ class ChatModel(BaseModel):
             raise ValueError("Can not setup Tools and JSON Schema at the same time")
         return self
 
-    @model_validator(mode="after")
-    def check_reasoning_budget_vs_max_tokens(self) -> "ChatModel":
-        if isinstance(self.reasoning, Reasoning) and self.max_tokens is not None:
-            if self.reasoning.budget_tokens >= self.max_tokens:
-                raise ValueError(
-                    f"`budget_tokens` ({self.reasoning.budget_tokens}) cannot be greater or equal than `max_tokens` ({self.max_tokens})."
-                )
-        return self
+    @field_serializer("reasoning")
+    def serialize_reasoning(
+        self, v: Union["Reasoning", bool]
+    ) -> Union[Dict[str, Any], bool]:
+        if isinstance(v, Reasoning):
+            return v.model_dump(exclude_unset=True)
+        return v
 
 
 class Token(BaseModel):

--- a/nuclia/tests/unit/test_nua_responses.py
+++ b/nuclia/tests/unit/test_nua_responses.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nuclia.lib.nua_responses import PushPayload, Reasoning
+from nuclia.lib.nua_responses import ChatModel, PushPayload, Reasoning
 
 
 def test_uuid_validation():
@@ -13,35 +13,46 @@ def test_uuid_validation():
         PushPayload(uuid="invalid.uuid")
 
 
-@pytest.mark.parametrize(
-    "effort,expected_budget_tokens",
-    [
-        ("none", 0),
-        ("minimal", 0),
-        ("low", 7500),
-        ("medium", 15_000),
-        ("high", 30_000),
-        ("xhigh", 50_000),
-    ],
-)
-def test_reasoning_effort_sets_budget_tokens(effort, expected_budget_tokens):
-    r = Reasoning(effort=effort)
-    assert r.budget_tokens == expected_budget_tokens
+def test_reasoning_serializes_only_set_fields_in_chat_model():
+    def reasoning_payload(r: Reasoning) -> dict:
+        return ChatModel(question="q", user_id="u", reasoning=r).model_dump()[
+            "reasoning"
+        ]
+
+    assert reasoning_payload(Reasoning(effort="high")) == {"effort": "high"}
+    assert reasoning_payload(Reasoning(budget_tokens=1024)) == {"budget_tokens": 1024}
+    assert reasoning_payload(Reasoning(effort="xhigh", budget_tokens=1024)) == {
+        "effort": "xhigh",
+        "budget_tokens": 1024,
+    }
+    assert reasoning_payload(Reasoning(display=False)) == {"display": False}
+    assert reasoning_payload(Reasoning()) == {}
 
 
-@pytest.mark.parametrize(
-    "budget_tokens,expected_effort",
-    [
-        (0, "low"),
-        (7500, "low"),
-        (7501, "medium"),
-        (15_000, "medium"),
-        (15_001, "high"),
-        (30_000, "high"),
-        (30_001, "xhigh"),
-        (50_000, "xhigh"),
-    ],
-)
-def test_reasoning_budget_tokens_sets_effort(budget_tokens, expected_effort):
-    r = Reasoning(budget_tokens=budget_tokens)
-    assert r.effort == expected_effort
+def test_reasoning_effort_and_budget_tokens_are_independent():
+    # Effort and budget_tokens are no longer coupled client-side.
+    # The learning normalization layer handles any effort↔budget mapping.
+    r = Reasoning(effort="high")
+    assert r.effort == "high"
+    assert r.budget_tokens == 15_000  # default, not overridden by effort
+
+    r2 = Reasoning(budget_tokens=1024)
+    assert r2.budget_tokens == 1024
+    assert r2.effort == "medium"  # default, not overridden by budget_tokens
+
+    # Both can be set independently; learning will normalize them.
+    r3 = Reasoning(effort="low", budget_tokens=99_999)
+    assert r3.effort == "low"
+    assert r3.budget_tokens == 99_999
+
+
+def test_chat_model_does_not_enforce_budget_tokens_vs_max_tokens():
+    # The budget_tokens > max_tokens constraint was intentionally removed.
+    # Validation is delegated to the learning normalization layer.
+    chat = ChatModel(
+        question="q",
+        user_id="u",
+        max_tokens=100,
+        reasoning=Reasoning(budget_tokens=99_999),
+    )
+    assert chat.reasoning.budget_tokens == 99_999  # type: ignore[union-attr]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuclia"
-version = "4.11.2"
+version = "4.11.1"
 license = "MIT"
 description = "Nuclia Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuclia"
-version = "4.11.1"
+version = "4.11.2"
 license = "MIT"
 description = "Nuclia Python SDK"
 readme = "README.md"


### PR DESCRIPTION
The `Reasoning` model in `nua_responses.py` had client-side logic that duplicated the normalization layer in learning:
- A `model_validator` that mapped `effort ↔ budget_tokens` bidirectionally
- A `check_reasoning_budget_vs_max_tokens` validator in `ChatModel`

Both are now handled by the learning normalization layer, so they've been removed.

**Changes:**
- Replace `model_validator` with a `model_serializer` that only serializes explicitly set fields — learning receives exactly what the user configured and handles all mappings
- Remove `check_reasoning_budget_vs_max_tokens` from `ChatModel` — learning clamps `budget_tokens` silently via `_clamp_reasoning_budget_tokens`
- Update tests to reflect the new serialization contract