### PR TITLE
fix: use json parameter instead of  of data on json requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.11.3 (2026-06-15)
+
+### Bug Fixes
+
+- use json= instead of data=/content= for httpx request body serialization
+
 ## 4.11.2 (2026-06-03)
 
 - Add new reasoning effort values `none`, `minimal`, `xhigh`

--- a/nuclia/sdk/auth.py
+++ b/nuclia/sdk/auth.py
@@ -696,7 +696,7 @@ class NucliaAuth(BaseNucliaAuth):
         if data is not None:
             if remove_null:
                 data = {k: v for k, v in data.items() if v is not None}
-            kwargs["content"] = json.dumps(data)
+            kwargs["json"] = data
 
         resp = self.client.request(
             method,
@@ -733,7 +733,7 @@ class NucliaAuth(BaseNucliaAuth):
         if data is not None:
             if remove_null:
                 data = {k: v for k, v in data.items() if v is not None}
-            kwargs["content"] = json.dumps(data)
+            kwargs["json"] = data
 
         resp = self.client.request(
             method,
@@ -1290,7 +1290,7 @@ class AsyncNucliaAuth(BaseNucliaAuth):
         if data is not None:
             if remove_null:
                 data = {k: v for k, v in data.items() if v is not None}
-            kwargs["data"] = json.dumps(data)
+            kwargs["json"] = data
         resp = await self.client.request(
             method,
             path,
@@ -1327,7 +1327,7 @@ class AsyncNucliaAuth(BaseNucliaAuth):
         if data is not None:
             if remove_null:
                 data = {k: v for k, v in data.items() if v is not None}
-            kwargs["data"] = json.dumps(data)
+            kwargs["json"] = data
         resp = await self.client.request(
             method,
             path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuclia"
-version = "4.11.2"
+version = "4.11.3"
 license = "MIT"
 description = "Nuclia Python SDK"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuclia"
-version = "4.11.3"
+version = "4.11.4"
 license = "MIT"
 description = "Nuclia Python SDK"
 readme = "README.md"


### PR DESCRIPTION
## Problem

An upgrade to core components to FastAPI 0.136 + Starlette 1.3 + Pydantic 2.12, some POST endpoints receiving JSON bodies from this SDK started returning 422 errors:

```
Input should be a valid dictionary or object to extract fields from
```

The root cause is that the SDK was sending bodies using httpx's `data=json.dumps(payload)` (async) and `content=json.dumps(payload)` (sync). Neither sets `Content-Type: application/json` — the server receives a raw string that it can't parse as a model.

Old FastAPI/Starlette tolerated this by double-decoding the stringified JSON, but the new versions strictly expect a proper JSON content-type.

## Fix

Replace all 4 occurrences (`_request` and `_nua_request`, both sync and async) with `json=data`, which makes httpx handle serialization and content-type automatically.
